### PR TITLE
fix: remove tilde requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ license = "MPL-2.0"
 edition = "2018"
 
 [dependencies]
-mdbook = "~0.4"
-serde = "~1.0"
-serde_derive = "~1.0"
-regex = "~1.5"
-lazy_static = "~1.4"
+mdbook = "0.4"
+serde = "1.0"
+serde_derive = "1.0"
+regex = "1.5"
+lazy_static = "1.4"


### PR DESCRIPTION
Hi there 👋🏻 

> Quick aside, love the plugin, I'm actually trying to get my book published so this was super handy. Also its really nicely written and was easy to understand, thank you!

Problem description:

I ran into an issue running the plugin with my book: https://github.com/Fios-Quest/idiomatic-rust-in-simple-steps

I'd get the following error

```
2025-09-24 13:23:34 [INFO] (mdbook::book): Running the wordcount backend
2025-09-24 13:23:34 [INFO] (mdbook::renderer): Invoking the "wordcount" renderer

thread 'main' panicked at /Users/daniel/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/mdbook-wordcount-1.0.1/src/main.rs:41:52:
called `Result::unwrap()` on an `Err` value: Unable to deserialize the `RenderContext`

Caused by:
    unknown variant `2024`, expected one of `2021`, `2018`, `2015` for key `edition` at line 1 column 572742
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2025-09-24 13:23:34 [ERROR] (mdbook::renderer): Renderer exited with non-zero return code.
2025-09-24 13:23:34 [ERROR] (mdbook::utils): Error: Rendering failed
2025-09-24 13:23:34 [ERROR] (mdbook::utils):    Caused By: The "wordcount" renderer failed
```

As it happens, I'd seen this before when I was using an older version of mdbook before that didn't support 2024, but after updating it was fine. I wasn't sure why I was getting it again after adding the wordcount plugin. The version of mdbook used in mdbook-wordcount is `~0.4` which should include the latest version (currently `0.4.52`).

I believe the issue was the `~` restriction on lazy_static. Because lazy_static was set to `~1.4` and the version [mdbook uses is 1.5](https://github.com/rust-lang/mdBook/blob/aa96e1174e671334b872bbbf93a87b7804a76a2f/Cargo.lock#L892-L893), cargo had to resolve a version of mdbook that use a `1.4.X` version of lazy_static.

Because [Cargo kind of ignores SemVer](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#default-requirements) for versions < 1.0.0, it's safe to use `mdbook = "0.4"` and it won't go to version `>= 0.5`.

Solution:

Removing the tilde restriction from all dependencies and installing locally resolved the issue.

Note: I guess you'll need to publish a 1.0.2 version for everyone to get the fix?